### PR TITLE
also use the proxy for https requests

### DIFF
--- a/default.py
+++ b/default.py
@@ -57,7 +57,7 @@ class My_Pandora( Pandora ):
 
 	def set_proxy(self, proxy):
 		if proxy:
-			proxy_handler = urllib2.ProxyHandler({'http': proxy})
+			proxy_handler = urllib2.ProxyHandler({'http': proxy, 'https': proxy})
 			self.opener = urllib2.build_opener(proxy_handler)
 			## _or_ set_url_opener()
 			#self.set_url_opener( urllib2.build_opener(proxy_handler) )


### PR DESCRIPTION
Pithos uses https for the authentication request.
We also have to send this request through the proxy, else the login fails.